### PR TITLE
MidiKeyboardComponent: Fix rounding error in xyToNote

### DIFF
--- a/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.cpp
+++ b/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.cpp
@@ -285,7 +285,7 @@ int MidiKeyboardComponent::getNoteAtPosition (Point<float> p)
 
 int MidiKeyboardComponent::xyToNote (Point<float> pos, float& mousePositionVelocity)
 {
-    if (! reallyContains (pos.toInt(), false))
+    if (! reallyContains (pos.roundToInt(), false))
         return -1;
 
     auto p = pos;


### PR DESCRIPTION
The mouse position can sometimes be incorrectly calculated as still
being inside the keyboard component due to an inaccurate rounding in
xyToNote(). This results in the last mouse over note still being
highlighted after mouseExit().